### PR TITLE
- stop error being returned when no user is specified in siteconfig

### DIFF
--- a/code/extensions/TwitterExtension.php
+++ b/code/extensions/TwitterExtension.php
@@ -28,7 +28,8 @@ class TwitterExtension extends Extension {
 	 * @return ArrayData
 	 */
 	public function LatestTweet() {
-		return $this->LatestTweets()->first();
+		$latestTweets = $this->LatestTweets();
+		return $latestTweets ? $latestTweets->first() : null;
 	}
 	
 	/**


### PR DESCRIPTION
Received the following error on a freshly created site (no config filled in) that stopped rendering of pages:

 PHP Fatal error:  Call to a member function first() on a non-object in [project root]/twitter/code/extensions/TwitterExtension.php on line 33